### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/luzfcb/django_documentos.png?label=ready&title=Ready 
+ :target: https://waffle.io/luzfcb/django_documentos
+ :alt: 'Stories in Ready'
 =============================
 django_documentos
 =============================


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/luzfcb/django_documentos

This was requested by a real person (user luzfcb) on waffle.io, we're not trying to spam you.
